### PR TITLE
fix apt with items usage

### DIFF
--- a/tasks/virtualbox.yml
+++ b/tasks/virtualbox.yml
@@ -24,14 +24,14 @@
 - name: VIRTUALBOX | install virtualbox
   become: true
   apt:
-    name: "{{ item }}"
+    name:
+      - "linux-headers-{{ ansible_kernel }}"
+      - dkms
+      - build-essential
+      - "virtualbox-{{ virtualbox_version }}"
     state: present
     update_cache: yes
-  with_items:
-    - "linux-headers-{{ ansible_kernel }}"
-    - dkms
-    - build-essential
-    - "virtualbox-{{ virtualbox_version }}"
+
 
 - name: VIRTUALBOX | add users to vb-group
   become: true


### PR DESCRIPTION
Hello! 

Please update role at galaxy.

I download via ansible-galaxy role and got error with invalid state

```
- name: VIRTUALBOX | install virtualbox
  become: true
  apt:
    name: "{{ item }}" 
    state: installed << invalid state
    update_cache: yes
    -
    
```
PR for fix warning

```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items 
and specifying `name: "{{ item }}"`, please use `name: ['linux-headers-{{ ansible_kernel }}', 'dkms', 'build-essential', 'virtualbox-{{ 
virtualbox_version }}']` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg
```